### PR TITLE
Feature/md 4649 api refactor and validation

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularClientCodegen.java
@@ -542,6 +542,15 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
         return apiPackage() + "/" + toApiFilename(name);
     }
 
+    /**
+     * Overriding toRegularExpression() to avoid escapeText() being called,
+     * as it would return a broken regular expression if any escaped character / metacharacter were present.
+     */
+    @Override
+    public String toRegularExpression(String pattern) {
+        return addRegularExpressionDelimiter(pattern);
+    }
+
     @Override
     public String toModelFilename(String name) {
         if (importMapping.containsKey(name)) {

--- a/modules/openapi-generator/src/main/resources/typescript-angular/api.service.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/api.service.mustache
@@ -9,7 +9,10 @@ import { flatMap } from 'rxjs/operators';
 
 // prettier-ignore
 // @ts-ignore
-import { isnumber, isstring, isboolean, getValidationErrorsnumber, getValidationErrorsstring, getValidationErrorsboolean, getValidationErrorsArray } from '../../primitive-types-checks';
+import { isnumber, isstring, isboolean, getValidationErrorsnumber, getValidationErrorsstring, getValidationErrorsboolean } from '../../primitive-types-checks';
+// prettier-ignore
+// @ts-ignore
+import { getValidationErrorsnumberArray, getValidationErrorsstringArray, getValidationErrorsbooleanArray } from '../../model-field';
 // prettier-ignore
 // @ts-ignore
 import { RequestBodyValidationError, RequestParameterValidationError, RequestQueryParameterValidationError, ResponseBodyValidationError, ResponseHttpStatusError } from '../../validation-errors';
@@ -17,7 +20,7 @@ import { RequestBodyValidationError, RequestParameterValidationError, RequestQue
 {{#imports}}
 // prettier-ignore
 // @ts-ignore
-import { {{classname}}, removeAdditionalPropertiesFrom{{classname}}, removeAdditionalPropertiesFromPartial{{classname}}, is{{classname}}, is{{classname}}Array, getValidationErrors{{classname}} } from '../model/models';
+import { {{classname}}, removeAdditionalPropertiesFrom{{classname}}, removeAdditionalPropertiesFromPartial{{classname}}, is{{classname}}, is{{classname}}Array, getValidationErrors{{classname}}, getValidationErrors{{classname}}Array } from '../model/models';
 {{/imports}}
 
 import { ApiConfig } from '../../api-config';
@@ -169,8 +172,14 @@ export class {{classname}} {
 {{#useSingleRequestParameter}}
         const {{paramName}} = requestParameters.{{paramName}};
 {{/useSingleRequestParameter}}
-        const {{paramName}}ValidationErrors = {{#isListContainer}}getValidationErrorsArray{{/isListContainer}}{{^isListContainer}}getValidationErrors{{^isEnum}}{{{dataType}}}{{/isEnum}}{{#isEnum}}{{#isString}}string{{/isString}}{{^isString}}number{{/isString}}{{/isEnum}}{{/isListContainer}}({{paramName}}, {{required}}{{^isPrimitiveType}}{{^isContainer}}, {{^isBodyParam}}false{{/isBodyParam}}{{#isBodyParam}}{{^isRestfulPartialUpdate}}false{{/isRestfulPartialUpdate}}{{#isRestfulPartialUpdate}}true{{/isRestfulPartialUpdate}}{{/isBodyParam}}{{/isContainer}}{{/isPrimitiveType}});
-        if ({{paramName}}ValidationErrors.length > 0) {
+        const {{paramName}}ValidationErrors =
+        {{#isListContainer}}
+        getValidationErrors{{{baseType}}}Array({{paramName}}, { required: {{required}}{{#minItems}}, minItems: {{minItems}}{{/minItems}}{{#maxItems}}, maxItems: {{maxItems}}{{/maxItems}} }{{#items}}{{#isPrimitiveType}}, { required: {{required}}{{#isNumeric}}{{#minimum}}, minimum: {{minimum}}{{/minimum}}{{#maximum}}, maximum: {{maximum}}{{/maximum}}{{/isNumeric}}{{#isString}}{{#pattern}}, pattern: {{pattern}}{{/pattern}}{{#format}}, format: '{{format}}'{{/format}}{{#minLength}}, minLength: {{minLength}}{{/minLength}}{{#maxLength}}, maxLength: {{maxLength}}{{/maxLength}}{{/isString}} }{{/isPrimitiveType}}{{/items}});
+        {{/isListContainer}}
+        {{^isListContainer}}
+        getValidationErrors{{^isEnum}}{{{dataType}}}{{/isEnum}}{{#isEnum}}{{#isString}}string{{/isString}}{{^isString}}number{{/isString}}{{/isEnum}}({{paramName}}, { required: {{required}}{{#isPrimitiveType}}{{#isNumeric}}{{#minimum}}, minimum: {{minimum}}{{/minimum}}{{#maximum}}, maximum: {{maximum}}{{/maximum}}{{/isNumeric}}{{#isString}}{{#pattern}}, pattern: {{pattern}}{{/pattern}}{{#format}}, format: '{{format}}'{{/format}}{{#minLength}}, minLength: {{minLength}}{{/minLength}}{{#maxLength}}, maxLength: {{maxLength}}{{/maxLength}}{{/isString}}{{/isPrimitiveType}} }{{^isPrimitiveType}}, {{^isBodyParam}}false{{/isBodyParam}}{{#isBodyParam}}{{^isRestfulPartialUpdate}}false{{/isRestfulPartialUpdate}}{{#isRestfulPartialUpdate}}true{{/isRestfulPartialUpdate}}{{/isBodyParam}}{{/isPrimitiveType}});
+        {{/isListContainer}}
+        if ({{paramName}}ValidationErrors) {
           return throwError(new {{#isQueryParam}}RequestQueryParameterValidationError{{/isQueryParam}}{{#isBodyParam}}RequestBodyValidationError{{/isBodyParam}}{{^isQueryParam}}{{^isBodyParam}}RequestParameterValidationError{{/isBodyParam}}{{/isQueryParam}}('{{classname}}.{{nickname}}', '{{paramName}}', {{paramName}}, {{paramName}}ValidationErrors));
         }
 {{/allParams}}
@@ -306,14 +315,14 @@ export class {{classname}} {
                     {{^is4xx}}{{^is5xx}}
                     case {{code}}:
                     {{#dataType}}
-                        return {{#isListContainer}}is{{{baseType}}}Array{{/isListContainer}}{{^isListContainer}}is{{{dataType}}}{{/isListContainer}}(responseBody, true)
+                        return {{#isListContainer}}is{{{baseType}}}Array(responseBody, { required: true{{#minItems}}, minItems: {{minItems}}{{/minItems}}{{#maxItems}}, maxItems: {{maxItems}}{{/maxItems}} }{{#items}}{{#isPrimitiveType}}, { required: {{required}}{{#isNumeric}}{{#minimum}}, minimum: {{minimum}}{{/minimum}}{{#maximum}}, maximum: {{maximum}}{{/maximum}}{{/isNumeric}}{{#isString}}{{#pattern}}, pattern: {{pattern}}{{/pattern}}{{#format}}, format: '{{format}}'{{/format}}{{#minLength}}, minLength: {{minLength}}{{/minLength}}{{#maxLength}}, maxLength: {{maxLength}}{{/maxLength}}{{/isString}} }{{/isPrimitiveType}}{{/items}}){{/isListContainer}}{{^isListContainer}}is{{{dataType}}}(responseBody, { required: true{{#isPrimitiveType}}{{#isNumeric}}{{#minimum}}, minimum: {{minimum}}{{/minimum}}{{#maximum}}, maximum: {{maximum}}{{/maximum}}{{/isNumeric}}{{#isString}}{{#pattern}}, pattern: {{pattern}}{{/pattern}}{{#format}}, format: '{{format}}'{{/format}}{{#minLength}}, minLength: {{minLength}}{{/minLength}}{{#maxLength}}, maxLength: {{maxLength}}{{/maxLength}}{{/isString}}{{/isPrimitiveType}} }){{/isListContainer}}
                             ? of(responseBody)
                             : throwError(
                                 new ResponseBodyValidationError(
                                   '{{classname}}.{{nickname}}',
                                   '{{{dataType}}}',
                                   responseBody,
-                                  {{#isListContainer}}getValidationErrorsArray(responseBody, true){{/isListContainer}}{{^isListContainer}}getValidationErrors{{{dataType}}}(responseBody, true{{^primitiveType}}, false{{/primitiveType}}){{/isListContainer}}
+                                  {{#isListContainer}}getValidationErrors{{{baseType}}}Array(responseBody, { required: true{{#minItems}}, minItems: {{minItems}}{{/minItems}}{{#maxItems}}, maxItems: {{maxItems}}{{/maxItems}} }{{#items}}{{#isPrimitiveType}}, { required: {{required}}{{#isNumeric}}{{#minimum}}, minimum: {{minimum}}{{/minimum}}{{#maximum}}, maximum: {{maximum}}{{/maximum}}{{/isNumeric}}{{#isString}}{{#pattern}}, pattern: {{pattern}}{{/pattern}}{{#format}}, format: '{{format}}'{{/format}}{{#minLength}}, minLength: {{minLength}}{{/minLength}}{{#maxLength}}, maxLength: {{maxLength}}{{/maxLength}}{{/isString}} }{{/isPrimitiveType}}{{/items}}){{/isListContainer}}{{^isListContainer}}getValidationErrors{{{dataType}}}(responseBody, { required: true{{#isPrimitiveType}}{{#isNumeric}}{{#minimum}}, minimum: {{minimum}}{{/minimum}}{{#maximum}}, maximum: {{maximum}}{{/maximum}}{{/isNumeric}}{{#isString}}{{#pattern}}, pattern: {{pattern}}{{/pattern}}{{#format}}, format: '{{format}}'{{/format}}{{#minLength}}, minLength: {{minLength}}{{/minLength}}{{#maxLength}}, maxLength: {{maxLength}}{{/maxLength}}{{/isString}}{{/isPrimitiveType}} }{{^isPrimitiveType}}, false{{/isPrimitiveType}}){{/isListContainer}}
                                 )
                               );
                     {{/dataType}}

--- a/modules/openapi-generator/src/main/resources/typescript-angular/model.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/model.mustache
@@ -1,15 +1,7 @@
 {{>licenseInfo}}
 {{#models}}
 {{#model}}
-{{#tsImports}}
-// prettier-ignore
-// @ts-ignore
-import { {{classname}}, removeAdditionalPropertiesFrom{{classname}}, removeAdditionalPropertiesFromPartial{{classname}}, getValidationErrors{{classname}} } from '{{filename}}';
-{{/tsImports}}
-// prettier-ignore
-// @ts-ignore
-import { isArray, getValidationErrorsArray, getValidationErrorsboolean, getValidationErrorsnumber, getValidationErrorsstring } from '../../primitive-types-checks';
-import { FieldValidationError } from '../../validation-errors';
+import { ArrayConstraints, ObjectConstraints } from '../../model-constraints';
 
 {{#description}}
 /**

--- a/modules/openapi-generator/src/main/resources/typescript-angular/modelEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/modelEnum.mustache
@@ -27,34 +27,22 @@ export function removeAdditionalPropertiesFromPartial{{classname}}(obj: Partial<
     throw new Error('removeAdditionalPropertiesFromPartial{{classname}} is not implemented!');
 }
 
-export function is{{classname}}(obj: any, isRequired: boolean): obj is {{classname}} {
-    return (!isRequired && (obj === null || obj === undefined)) || getValidationErrors{{classname}}(obj, isRequired, false).length === 0;
+export function is{{classname}}(obj: any, constraints: ObjectConstraints): obj is {{classname}} {
+    return !getValidationErrors{{classname}}(obj, constraints, false);
 }
 
-export function is{{classname}}Array(x: any, isRequired: boolean): x is Array<{{classname}}> {
-    return isArray(x, isRequired) && x.every(item => is{{classname}}(item, true));
+export function is{{classname}}Array(x: any, constraints: ArrayConstraints): x is Array<{{classname}}> {
+    return !getValidationErrors{{classname}}Array(x, constraints);
 }
 
-export function getValidationErrors{{classname}}(obj: any, isRequired: boolean, isPartial: boolean) {
-    if (isPartial) {
-        throw new Error('Enum model error validation must always be called with isPartial === false.')
-    }
-    const errors: FieldValidationError[] = [];
-    if (obj === null || obj === undefined) {
-        if (isRequired) {
-            errors.push({ fieldName: '.', expectedType: '{{{classname}}}', actualValue: obj });
-        }
-        return errors;
-    }
+export function getValidationErrors{{classname}}(obj: any, constraints: ObjectConstraints, isPartial: boolean) {
+    // NOT IMPLEMENTED
+    // Compiler should complain as soon as this code is generated since function parameters are unused.
+    return null;
+}
 
-    if (
-    {{#allowableValues}}
-    {{#enumVars}}
-    obj !== {{classname}}.{{{name}}}{{^-last}} && {{/-last}}
-    {{/enumVars}}
-    {{/allowableValues}}
-    ) {
-        errors.push({ fieldName: '.', expectedType: '{{{classname}}}', actualValue: obj });
-    }
-    return errors;
+export function getValidationErrors{{classname}}Array(obj: any, constraints: ArrayConstraints) {
+    // NOT IMPLEMENTED
+    // Compiler should complain as soon as this code is generated since function parameters are unused.
+    return null;
 }

--- a/modules/openapi-generator/src/main/resources/typescript-angular/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/modelGeneric.mustache
@@ -1,3 +1,12 @@
+{{#tsImports}}
+// prettier-ignore
+// @ts-ignore
+import { {{classname}}, modelFields{{classname}} } from '{{filename}}';
+{{/tsImports}}
+// prettier-ignore
+// @ts-ignore
+import { ModelFieldArray, ModelFieldboolean, ModelFieldnumber, ModelFieldObject, ModelFields, ModelFieldstring, removeAdditionalProperties } from '../../model-field';
+
 {{^vars}}/* tslint:disable:no-empty-interface */{{/vars}}
 export interface {{classname}}{{#allParents}}{{#-first}} extends {{/-first}}{{{.}}}{{^-last}}, {{/-last}}{{/allParents}} { {{>modelGenericAdditionalProperties}}
 {{#vars}}
@@ -10,83 +19,42 @@ export interface {{classname}}{{#allParents}}{{#-first}} extends {{/-first}}{{{.
 {{/vars}}
 }{{>modelGenericEnums}}
 
-export function removeAdditionalPropertiesFrom{{classname}}(obj: {{classname}}): {{classname}} {
-    return {
-        {{#allParents}}...removeAdditionalPropertiesFrom{{.}}(obj){{^-last}},
-        {{/-last}}{{#-last}}{{#vars}},
-        {{/vars}}{{/-last}}{{/allParents}}
+export interface ModelFields{{classname}} extends ModelFields {
     {{#vars}}
-        {{name}}: {{#isListContainer}}obj.{{name}}{{^required}}?{{/required}}.map(item => {{#items.isPrimitiveType}}item{{/items.isPrimitiveType}}{{^items.isPrimitiveType}}removeAdditionalPropertiesFrom{{{items.dataType}}}(item){{/items.isPrimitiveType}}){{/isListContainer}}{{^isListContainer}}{{#isPrimitiveType}}obj.{{name}}{{/isPrimitiveType}}{{^isPrimitiveType}}{{^required}}obj.{{name}} ? {{/required}}removeAdditionalPropertiesFrom{{{dataType}}}(obj.{{name}}){{^required}} : undefined{{/required}}{{/isPrimitiveType}}{{/isListContainer}}{{#hasMore}},{{/hasMore}}
+    {{{name}}}: {{^isListContainer}}{{#isPrimitiveType}}ModelField{{{dataType}}}{{/isPrimitiveType}}{{^isPrimitiveType}}ModelFieldObject{{/isPrimitiveType}}{{/isListContainer}}{{#isListContainer}}ModelFieldArray{{/isListContainer}};
     {{/vars}}
-    };
+}
+
+export const modelFields{{classname}}: ModelFields{{classname}} = {
+    {{#vars}}
+    {{{name}}}:
+    {{^isListContainer}}{{#isPrimitiveType}}new ModelField{{{dataType}}}('{{{name}}}', { required: {{required}}{{#isNumeric}}{{#minimum}}, minimum: {{minimum}}{{/minimum}}{{#maximum}}, maximum: {{maximum}}{{/maximum}}{{/isNumeric}}{{#isString}}{{#pattern}}, pattern: {{pattern}}{{/pattern}}{{#format}}, format: '{{format}}'{{/format}}{{#minLength}}, minLength: {{minLength}}{{/minLength}}{{#maxLength}}, maxLength: {{maxLength}}{{/maxLength}}{{/isString}} }){{/isPrimitiveType}}{{^isPrimitiveType}}new ModelFieldObject('{{{name}}}', { required: {{required}} }, modelFields{{{dataType}}}, false){{/isPrimitiveType}}{{/isListContainer}}
+    {{#isListContainer}}{{#items.isPrimitiveType}}new ModelFieldArray('{{{name}}}', { required: {{required}}{{#minItems}}, minItems: {{minItems}}{{/minItems}}{{#maxItems}}, maxItems: {{maxItems}}{{/maxItems}} }, new ModelField{{{items.dataType}}}('{{{name}}}', { required: {{required}} })){{/items.isPrimitiveType}}{{^items.isPrimitiveType}}new ModelFieldArray('{{{name}}}', { required: true{{#minItems}}, minItems: {{minItems}}{{/minItems}}{{#maxItems}}, maxItems: {{maxItems}}{{/maxItems}} }, new ModelFieldObject('', { required: true }, modelFields{{{complexType}}}, false)){{/items.isPrimitiveType}}{{/isListContainer}},
+    {{/vars}}
+};
+
+export function removeAdditionalPropertiesFrom{{classname}}(obj: {{classname}}): {{classname}} {
+    return removeAdditionalProperties<{{classname}}>(obj, modelFields{{classname}});
 }
 
 export function removeAdditionalPropertiesFromPartial{{classname}}(obj: Partial<{{classname}}>) {
-    const ret: Partial<{{classname}}> = {
-        {{#allParents}}...removeAdditionalPropertiesFromPartial{{.}}(obj){{^-last}},{{/-last}}
-        {{/allParents}}
-    };
-
-    {{#vars}}
-    if (obj.hasOwnProperty('{{name}}'){{#required}}{{#isListContainer}} && obj.{{name}}{{/isListContainer}}{{^isListContainer}}{{^isPrimitiveType}} && obj.{{name}}{{/isPrimitiveType}}{{/isListContainer}}{{/required}}) {
-        ret.{{name}} = {{#isListContainer}}obj.{{name}}{{^required}}?{{/required}}.map(item => {{#items.isPrimitiveType}}item{{/items.isPrimitiveType}}{{^items.isPrimitiveType}}removeAdditionalPropertiesFrom{{{items.dataType}}}(item){{/items.isPrimitiveType}}){{/isListContainer}}{{^isListContainer}}{{#isPrimitiveType}}obj.{{name}}{{/isPrimitiveType}}{{^isPrimitiveType}}{{^required}}obj.{{name}} ? {{/required}}removeAdditionalPropertiesFrom{{{dataType}}}(obj.{{name}}){{^required}} : undefined{{/required}}{{/isPrimitiveType}}{{/isListContainer}};
-    }
-    {{/vars}}
-
-    return ret;
+    return removeAdditionalProperties<Partial<{{classname}}>>(obj, modelFields{{classname}});
 }
 
-export function is{{classname}}(obj: any, isRequired: boolean): obj is {{classname}} {
-    return (!isRequired && (obj === null || obj === undefined)) || getValidationErrors{{classname}}(obj, isRequired, false).length === 0;
+export function is{{classname}}(obj: any, constraints: ObjectConstraints): obj is {{classname}} {
+    return !getValidationErrors{{classname}}(obj, constraints, false);
 }
 
-export function is{{classname}}Array(x: any, isRequired: boolean): x is Array<{{classname}}> {
-    return isArray(x, isRequired) && x.every(item => is{{classname}}(item, true));
+export function is{{classname}}Array(x: any, constraints: ArrayConstraints): x is Array<{{classname}}> {
+    return !getValidationErrors{{classname}}Array(x, constraints);
 }
 
-export function getValidationErrors{{classname}}(obj: any, isRequired: boolean, isPartial: boolean) {
-    const errors: FieldValidationError[] = {{^allParents}}[];{{/allParents}}{{#allParents}}[
-        ...getValidationErrors{{.}}(obj, isRequired, isPartial){{^-last}},{{/-last}}
-    ];{{/allParents}}
+export function getValidationErrors{{classname}}(obj: any, constraints: ObjectConstraints, isPartial: boolean) {
+    const modelField = new ModelFieldObject('{{classname}}', constraints, modelFields{{classname}}, isPartial);
+    return modelField.getValidationErrors(obj);
+}
 
-    if (obj === null || obj === undefined) {
-        if (isRequired) {
-            errors.push({ fieldName: '.', expectedType: '{{{classname}}}', actualValue: obj });
-        }
-        return errors;
-    }
-    {{#vars}}
-    {{#isListContainer}}
-    if ((!isPartial || obj.hasOwnProperty('{{name}}')) && getValidationErrorsArray(obj.{{name}}, {{required}}).length > 0) {
-        errors.push({ fieldName: '{{name}}', expectedType: '{{{dataType}}}', actualValue: obj.{{name}} });
-    }
-    else if (obj.{{name}}) {
-        obj.{{name}}.forEach((item: any, index: number) => {
-            const fieldErrors = getValidationErrors{{{items.dataType}}}(item, true{{^items.isPrimitiveType}}{{^items.isContainer}}, false{{/items.isContainer}}{{/items.isPrimitiveType}});
-            if (fieldErrors.length > 0) {
-                errors.push({
-                    fieldName: `obj.{{name}}[${index}]`,
-                    expectedType: '{{items.dataType}}',
-                    actualValue: item,
-                    errors: fieldErrors
-                });
-            }
-        });
-    }
-    {{/isListContainer}}
-    {{^isListContainer}}
-    {{#isPrimitiveType}}
-    if ((!isPartial || obj.hasOwnProperty('{{name}}')) && getValidationErrors{{{dataType}}}(obj.{{name}}, {{required}}).length > 0) {
-        errors.push({ fieldName: '{{name}}', expectedType: '{{{dataType}}}', actualValue: obj.{{name}} });
-    }
-    {{/isPrimitiveType}}
-    {{^isPrimitiveType}}
-    const {{{name}}}ValidationErrors = (!isPartial || obj.hasOwnProperty('{{name}}')) ? getValidationErrors{{{dataType}}}(obj.{{name}}, {{required}}, false) : [];
-    if ({{{name}}}ValidationErrors.length > 0) {
-        errors.push({ fieldName: '{{name}}', expectedType: '{{{dataType}}}', actualValue: obj.{{name}}, errors: {{{name}}}ValidationErrors });
-    }
-    {{/isPrimitiveType}}
-    {{/isListContainer}}
-    {{/vars}}
-    return errors;
+export function getValidationErrors{{classname}}Array(obj: any, constraints: ArrayConstraints) {
+  const modelField = new ModelFieldArray('{{classname}}Array', constraints, new ModelFieldObject('{{classname}}', constraints, modelFields{{classname}}, false));
+  return modelField.getValidationErrors(obj);
 }

--- a/modules/openapi-generator/src/main/resources/typescript-angular/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/modelOneOf.mustache
@@ -8,8 +8,9 @@ import {
 {{/hasImports}}
 
 {{#tsImports}}
-import { is{{classname}} } from '{{filename}}';
+import { is{{classname}}, {{classname}}, removeAdditionalPropertiesFrom{{classname}}, getValidationErrors{{classname}}, getValidationErrors{{classname}}Array } from '{{filename}}';
 {{/tsImports}}
+import { FieldValidationError } from '../../validation-errors';
 
 /**
  * @type {{classname}}{{#description}}
@@ -20,35 +21,33 @@ export type {{classname}} = {{#oneOf}}{{{.}}}{{^-last}} | {{/-last}}{{/oneOf}};
 
 export function removeAdditionalPropertiesFrom{{classname}}(obj: {{classname}}) {
     {{#oneOf}}
-    if (is{{{.}}}(obj, true)) {
+    if (is{{{.}}}(obj, { required: true })) {
         return removeAdditionalPropertiesFrom{{{.}}}(obj);
     }
     {{/oneOf}}
     return null;
 }
 
-export function is{{classname}}(obj: any, isRequired: boolean): obj is {{classname}} {
-    return (!isRequired && (obj === null || obj === undefined)) || getValidationErrors{{classname}}(obj, isRequired, false).length === 0;
+export function is{{classname}}(obj: any, constraints: ObjectConstraints): obj is {{classname}} {
+    return !getValidationErrors{{classname}}(obj, constraints, false);
 }
 
-export function is{{classname}}Array(x: any, isRequired: boolean): x is Array<{{classname}}> {
-    return isArray(x, isRequired) && x.every(item => is{{classname}}(item, true));
+export function is{{classname}}Array(x: any, constraints: ArrayConstraints): x is Array<{{classname}}> {
+    return !getValidationErrors{{classname}}Array(x, constraints);
 }
 
-export function getValidationErrors{{classname}}(obj: any, isRequired: boolean, isPartial: boolean) {
-    let errors: FieldValidationError[] = [];
-    if (obj === null || obj === undefined) {
-        if (isRequired) {
-            errors.push({ fieldName: '.', expectedType: '{{{classname}}}', actualValue: obj });
-        }
-        return errors;
-    }
-
+export function getValidationErrors{{classname}}(obj: any, constraints: ObjectConstraints, isPartial: boolean): FieldValidationError | null {
     const groupedErrors = [
-        {{#oneOf}}getValidationErrors{{.}}(obj, true, isPartial){{^-last}},{{/-last}}
+        {{#oneOf}}getValidationErrors{{.}}(obj, constraints, isPartial){{^-last}},{{/-last}}
         {{/oneOf}}
     ];
+    return groupedErrors.some(errorGroup => errorGroup === null) ? null : groupedErrors.find(errorGroup => errorGroup !== null) ?? null;
+}
 
-    errors = groupedErrors.some(errorGroup => errorGroup.length === 0) ? [] : groupedErrors.find(errorGroup => errorGroup.length > 0) ?? [];
-    return errors;
+export function getValidationErrors{{classname}}Array(obj: any, constraints: ArrayConstraints) {
+    const groupedErrors = [
+        {{#oneOf}}getValidationErrors{{.}}Array(obj, constraints){{^-last}},{{/-last}}
+        {{/oneOf}}
+    ];
+    return groupedErrors.some(errorGroup => errorGroup === null) ? null : groupedErrors.find(errorGroup => errorGroup !== null) ?? null;
 }


### PR DESCRIPTION
Die Generierung ist nun so angepasst, dass etwas weniger Code generiert wird, da jetzt generische Methoden aus dem moneymeets-app-Projekt aufgerufen werden, anstatt in jeder Model-Klasse die Validierung separat zu implementieren.

Darüber hinaus wurde die Generierung angepasst, sodass nun die Constraints aus der API-Spec validiert werden.