### PR TITLE
feat(model): improve validation error for oneOf models

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-angular/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/modelOneOf.mustache
@@ -41,7 +41,14 @@ export function getValidationErrors{{classname}}(obj: any, constraints: ObjectCo
         {{#oneOf}}getValidationErrors{{.}}(obj, constraints, isPartial){{^-last}},{{/-last}}
         {{/oneOf}}
     ];
-    return groupedErrors.some(errorGroup => errorGroup === null) ? null : groupedErrors.find(errorGroup => errorGroup !== null) ?? null;
+    return groupedErrors.some(errorGroup => errorGroup === null)
+        ? null
+        : {
+              fieldName: '{{classname}}',
+              expectedType: '{{#oneOf}}{{{.}}}{{^-last}} | {{/-last}}{{/oneOf}}',
+              actualValue: obj,
+              errors: groupedErrors as FieldValidationError[]
+          };
 }
 
 export function getValidationErrors{{classname}}Array(obj: any, constraints: ArrayConstraints) {
@@ -49,5 +56,13 @@ export function getValidationErrors{{classname}}Array(obj: any, constraints: Arr
         {{#oneOf}}getValidationErrors{{.}}Array(obj, constraints){{^-last}},{{/-last}}
         {{/oneOf}}
     ];
-    return groupedErrors.some(errorGroup => errorGroup === null) ? null : groupedErrors.find(errorGroup => errorGroup !== null) ?? null;
+    return groupedErrors.some(errorGroup => errorGroup === null)
+        ? null
+        : {
+              fieldName: '{{classname}}',
+              expectedType: 'Array<{{#oneOf}}{{{.}}}{{^-last}} | {{/-last}}{{/oneOf}}>',
+              actualValue: obj,
+              errors: groupedErrors as FieldValidationError[]
+        };
+;
 }


### PR DESCRIPTION
Korrektur der ValidationErrors für oneOf-Models.
Der generierte Code kann in Branch https://bitbucket.org/moneymeets/moneymeets-app/branch/feature/MD-4937-api-validation-errors geprüft werden.

Ziel ist, dass bei oneOf-Models alle Typen in den Fehlermeldungen auftauchen und nicht ein willkürlicher.

@mm-matthias @zyv FYI