### PR TITLE
refactor(app): replace obsolete rxjs operator flatMap with mergeMap

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-angular/api.service.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/api.service.mustache
@@ -5,7 +5,7 @@ import { Injectable, Optional } from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams, HttpParameterCodec } from '@angular/common/http';
 import { CustomHttpParameterCodec } from '../encoder';
 import { of, throwError } from 'rxjs';
-import { flatMap } from 'rxjs/operators';
+import { mergeMap } from 'rxjs/operators';
 
 // prettier-ignore
 // @ts-ignore
@@ -308,7 +308,7 @@ export class {{classname}} {
                 observe: 'response'
             }
         ).pipe(
-            flatMap(response => {
+            mergeMap(response => {
                 const responseBody = response.body;
                 switch (response.status) {
                 {{#responses}}


### PR DESCRIPTION
RxJS' operator `flatMap` is deprecated and should be replaced with `mergeMap`.