### PR TITLE
chore(ci): add workflow to build and publish docker image

### DIFF
--- a/.github/workflows/moneymeets-ci.yml
+++ b/.github/workflows/moneymeets-ci.yml
@@ -1,0 +1,24 @@
+name: CI
+on: [ push ]
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 15
+
+    env:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      DOCKER_REGISTRY: moneymeets/openapi-generator
+      TAG: frontend
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build image
+        run: docker build -t $DOCKER_REGISTRY:$TAG .
+
+      - name: Publish image
+        if: github.ref == 'refs/heads/moneymeets-typescript-angular'
+        run: |
+          docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+          docker push $DOCKER_REGISTRY:$TAG


### PR DESCRIPTION
Dieser CI Workflow baut die Images bei allen Pushes.
Das Uploaden des Images zu DockerHub erfolgt lediglich für unseren `master` Branch (`moneymeets-typescript-angular`).

@zyv FYI