### PR TITLE
Feature/md 5992 improve api generation

### DIFF
--- a/.run/Generate Insurance API.run.xml
+++ b/.run/Generate Insurance API.run.xml
@@ -4,7 +4,7 @@
     <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
     <option name="MAIN_CLASS_NAME" value="org.openapitools.codegen.OpenAPIGenerator" />
     <module name="openapi-generator-cli" />
-    <option name="PROGRAM_PARAMETERS" value="generate -i ../django-insurance-api-v2/api/spec/api.yml -g typescript-angular -o ../moneymeets-app/src/api/insurance -p fileNaming=kebab-case -p providedInRoot=true -p apiModulePrefix=Insurance -p serviceSuffix=ApiService -p serviceFileSuffix=-api.service -p stringEnums=true -p enumPropertyNaming=UPPERCASE -p apiName=insurance -p generateSupportingFiles=false" />
+    <option name="PROGRAM_PARAMETERS" value="generate -i ../django-insurance-api-v2/api/spec/api.yml -g typescript-angular -o ../moneymeets-app/src/api/insurance -p fileNaming=kebab-case -p providedInRoot=true -p apiModulePrefix=Insurance -p serviceSuffix=ApiService -p serviceFileSuffix=-api.service -p stringEnums=true -p enumPropertyNaming=UPPERCASE -p apiName=insurance" />
     <method v="2">
       <option name="Make" enabled="true" />
     </method>

--- a/.run/Generate Insurance API.run.xml
+++ b/.run/Generate Insurance API.run.xml
@@ -4,7 +4,7 @@
     <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
     <option name="MAIN_CLASS_NAME" value="org.openapitools.codegen.OpenAPIGenerator" />
     <module name="openapi-generator-cli" />
-    <option name="PROGRAM_PARAMETERS" value="generate -i ../django-insurance-api-v2/api/spec/api.yml -g typescript-angular -o ../moneymeets-app/src/api/insurance -p fileNaming=kebab-case -p providedInRoot=true -p apiModulePrefix=Insurance -p serviceSuffix=ApiService -p serviceFileSuffix=-api.service -p stringEnums=true -p enumPropertyNaming=UPPERCASE -p apiName=insurance" />
+    <option name="PROGRAM_PARAMETERS" value="generate -i ../django-insurance-api-v2/api/spec/api.yml -g typescript-angular -o ../moneymeets-app/src/api/insurance -p fileNaming=kebab-case -p providedInRoot=true -p apiModulePrefix=Insurance -p serviceSuffix=ApiService -p serviceFileSuffix=-api.service -p stringEnums=true -p enumPropertyNaming=UPPERCASE -p apiName=insurance -p generateSupportingFiles=false" />
     <method v="2">
       <option name="Make" enabled="true" />
     </method>

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularClientCodegen.java
@@ -86,6 +86,7 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
         embeddedTemplateDir = templateDir = "typescript-angular";
         modelTemplateFiles.put("model.mustache", ".ts");
         apiTemplateFiles.put("api.service.mustache", ".ts");
+        apiTemplateFiles.put("api.url.mustache", ".ts");
         languageSpecificPrimitives.add("Blob");
         typeMapping.put("file", "Blob");
         apiPackage = "api";
@@ -362,6 +363,7 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
 
         // Add filename information for api imports
         objs.put("apiFilename", getApiFilenameFromClassname(objs.get("classname").toString()));
+        operations.put("baseNameKebabCase", this.convertUsingFileNamingConvention(objs.get("pathPrefix").toString()));
 
         List<CodegenOperation> ops = (List<CodegenOperation>) objs.get("operation");
         boolean hasSomeFormParams = false;
@@ -532,6 +534,15 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
             return "default.service";
         }
         return this.convertUsingFileNamingConvention(name) + serviceFileSuffix;
+    }
+
+    @Override
+    public String apiFilename(String templateName, String tag) {
+        String suffix = apiTemplateFiles().get(templateName);
+        if (templateName == "api.url.mustache") {
+            return apiFileFolder() + File.separator + this.convertUsingFileNamingConvention(tag) + ".url" + suffix;
+        }
+        return apiFileFolder() + File.separator + toApiFilename(tag) + suffix;
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularClientCodegen.java
@@ -135,11 +135,11 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
     @Override
     public void processOpts() {
         super.processOpts();
-        supportingFiles.add(
-                new SupportingFile("models.mustache", modelPackage().replace('.', File.separatorChar), "models.ts"));
-        supportingFiles
-                .add(new SupportingFile("apis.mustache", apiPackage().replace('.', File.separatorChar), "api.ts"));
-        supportingFiles.add(new SupportingFile("index.mustache", getIndexDirectory(), "index.ts"));
+        // supportingFiles.add(
+        //         new SupportingFile("models.mustache", modelPackage().replace('.', File.separatorChar), "models.ts"));
+        // supportingFiles
+        //         .add(new SupportingFile("apis.mustache", apiPackage().replace('.', File.separatorChar), "api.ts"));
+        // supportingFiles.add(new SupportingFile("index.mustache", getIndexDirectory(), "index.ts"));
         supportingFiles.add(new SupportingFile("api.module.mustache", getIndexDirectory(), "api.module.ts"));
         supportingFiles.add(new SupportingFile("configuration.mustache", getIndexDirectory(), "configuration.ts"));
         supportingFiles.add(new SupportingFile("variables.mustache", getIndexDirectory(), "variables.ts"));

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularClientCodegen.java
@@ -136,6 +136,12 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
     @Override
     public void processOpts() {
         super.processOpts();
+        ////////////
+        // The flag `generateSupportingFiles` does not really make sense for this generator, since all supporting files
+        // except models.ts, api.ts and index.ts are always needed and it should never be possible to not generate them.
+        // Therefore, we disabled generating models.ts, api.ts and index.ts by simply commenting out the code.
+        ////////////
+
         // supportingFiles.add(
         //         new SupportingFile("models.mustache", modelPackage().replace('.', File.separatorChar), "models.ts"));
         // supportingFiles

--- a/modules/openapi-generator/src/main/resources/typescript-angular/api.service.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/api.service.mustache
@@ -20,7 +20,7 @@ import { RequestBodyValidationError, RequestParameterValidationError, RequestQue
 {{#imports}}
 // prettier-ignore
 // @ts-ignore
-import { {{classname}}, removeAdditionalPropertiesFrom{{classname}}, removeAdditionalPropertiesFromPartial{{classname}}, is{{classname}}, is{{classname}}Array, getValidationErrors{{classname}}, getValidationErrors{{classname}}Array } from '../model/models';
+import { {{classname}}, removeAdditionalPropertiesFrom{{classname}}, removeAdditionalPropertiesFromPartial{{classname}}, is{{classname}}, is{{classname}}Array, getValidationErrors{{classname}}, getValidationErrors{{classname}}Array } from '../{{import}}';
 {{/imports}}
 
 import { ApiConfig } from '../../api-config';

--- a/modules/openapi-generator/src/main/resources/typescript-angular/api.service.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/api.service.mustache
@@ -32,6 +32,8 @@ import {
 } from './{{classFilename}}Interface';
 {{/withInterfaces}}
 
+import { {{#operations}}{{#operation}}{{nickname}}Url{{#hasMore}}, {{/hasMore}}{{/operation}}{{/operations}} } from './{{baseNameKebabCase}}.url';
+
 {{#operations}}
 
 {{^withInterfaces}}
@@ -49,13 +51,6 @@ export interface {{#prefixParameterInterfaces}}{{classname}}{{/prefixParameterIn
 {{/operation}}
 {{/useSingleRequestParameter}}
 {{/withInterfaces}}
-
-{{#operation}}
-export function {{nickname}}Url({{#pathParams}}{{paramName}}: {{dataType}} | '*'{{#hasMore}}, {{/hasMore}}{{/pathParams}}) {
-    return {{#hasPathParams}}`{{{path}}}`{{/hasPathParams}}{{^hasPathParams}}'{{{path}}}'{{/hasPathParams}};
-}
-
-{{/operation}}
 
 {{#description}}
 /**

--- a/modules/openapi-generator/src/main/resources/typescript-angular/api.url.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/api.url.mustache
@@ -1,0 +1,8 @@
+{{#operations}}
+{{#operation}}
+export function {{nickname}}Url({{#pathParams}}{{paramName}}: {{dataType}} | '*'{{#hasMore}}, {{/hasMore}}{{/pathParams}}) {
+    return {{#hasPathParams}}`{{{path}}}`{{/hasPathParams}}{{^hasPathParams}}'{{{path}}}'{{/hasPathParams}};
+}
+
+{{/operation}}
+{{/operations}}


### PR DESCRIPTION
Implements MD-5992:
* Generate api url functions in separate files.
* Don't generate group export files.

This is a preparation for the Angular 13 update.
Cypress uses the api url functions, but it may not import Angular dependencies.
Therefore, api url functions must not be in the same files as the services.

To avoid importing some api functionality via the grouped files index.ts, models.ts and api.ts, which would lead to the same errors in Cypress tests, they are removed.

FYI @mm-matthias @zyv 