### PR TITLE
feat(actions): use aws ecr for openapi-generator image

### DIFF
--- a/.github/workflows/moneymeets-ci.yml
+++ b/.github/workflows/moneymeets-ci.yml
@@ -6,22 +6,25 @@ jobs:
     timeout-minutes: 15
 
     env:
-      DOCKER_REGISTRY: moneymeets/openapi-generator
+      DOCKER_REGISTRY: public.ecr.aws/moneymeets/openapi-generator
       TAG: frontend
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - name: Build image
-        run: docker build -t $DOCKER_REGISTRY:$TAG .
-
-      - name: Login to DockerHub
-        if: github.ref == 'refs/heads/moneymeets-typescript-angular'
-        uses: docker/login-action@v1
+      - uses: aws-actions/configure-aws-credentials@v2
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
 
-      - name: Publish image
+      - run: docker build -t $DOCKER_REGISTRY:$TAG .
+
+      - id: login-ecr-public
         if: github.ref == 'refs/heads/moneymeets-typescript-angular'
+        uses: aws-actions/amazon-ecr-login@v1
+        with:
+          registry-type: public
+
+      - if: github.ref == 'refs/heads/moneymeets-typescript-angular'
         run: docker push $DOCKER_REGISTRY:$TAG


### PR DESCRIPTION
### Description of the PR

use AWS ECR for openapi-generator image instead of DockerHub

