### PR TITLE
feat(api): remove obsolete eslint-disable @typescript-eslint/no-empty…

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-angular/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/modelGeneric.mustache
@@ -7,7 +7,6 @@ import { {{classname}}, ModelFields{{classname}}, modelFields{{classname}} } fro
 // @ts-ignore
 import { ModelFieldArray, ModelFieldboolean, ModelFieldnumber, ModelFieldObject, ModelFields, ModelFieldstring, removeAdditionalProperties } from '../../model-field';
 
-{{^vars}}/* eslint-disable @typescript-eslint/no-empty-interface */{{/vars}}
 export interface {{classname}}{{#allParents}}{{#-first}} extends {{/-first}}{{{.}}}{{^-last}}, {{/-last}}{{/allParents}} { {{>modelGenericAdditionalProperties}}
 {{#vars}}
     {{#description}}


### PR DESCRIPTION
…-interface

New typescript-eslint is configured with "@typescript-eslint/no-empty-object-type": ["error", { "allowInterfaces": "always" }]. Thus, this ignore is not needed anymore.

### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

