### PR TITLE
feat(api): fix ESLint errors for moneymeets-app

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-angular/api.url.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/api.url.mustache
@@ -1,6 +1,6 @@
 {{#operations}}
 {{#operation}}
-export function {{nickname}}Url({{#pathParams}}{{paramName}}: {{dataType}} | '*'{{#hasMore}}, {{/hasMore}}{{/pathParams}}) {
+export function {{nickname}}Url({{#pathParams}}{{paramName}}: {{dataType}}{{^isString}} | '*'{{/isString}}{{#hasMore}}, {{/hasMore}}{{/pathParams}}) {
     return {{#hasPathParams}}`{{{path}}}`{{/hasPathParams}}{{^hasPathParams}}'{{{path}}}'{{/hasPathParams}};
 }
 


### PR DESCRIPTION
Fix ESLint error `@typescript-eslint/no-redundant-type-constituents`.