### PR TITLE
feat(api): remove obsolete @ts-ignore and prettier-ignore comments

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-angular/api.service.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/api.service.mustache
@@ -3,24 +3,14 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams, HttpParameterCodec } from '@angular/common/http';
 import { CustomHttpParameterCodec } from '../encoder';
-// prettier-ignore
-// @ts-ignore
 import { throwError } from 'rxjs';
 import { map } from 'rxjs/operators';
 
-// prettier-ignore
-// @ts-ignore
 import { isnumber, isstring, isboolean, getValidationErrorsnumber, getValidationErrorsstring, getValidationErrorsboolean } from '../../primitive-types-checks';
-// prettier-ignore
-// @ts-ignore
 import { getValidationErrorsnumberArray, getValidationErrorsstringArray, getValidationErrorsbooleanArray } from '../../model-field';
-// prettier-ignore
-// @ts-ignore
 import { RequestBodyValidationError, RequestParameterValidationError, RequestQueryParameterValidationError, ResponseBodyValidationError, ResponseHttpStatusError } from '../../validation-errors';
 
 {{#imports}}
-// prettier-ignore
-// @ts-ignore
 import { {{classname}}, removeAdditionalPropertiesFrom{{classname}}, removeAdditionalPropertiesFromPartial{{classname}}, is{{classname}}, is{{classname}}Array, getValidationErrors{{classname}}, getValidationErrors{{classname}}Array } from '../{{import}}';
 {{/imports}}
 

--- a/modules/openapi-generator/src/main/resources/typescript-angular/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/modelGeneric.mustache
@@ -1,10 +1,6 @@
 {{#tsImports}}
-// prettier-ignore
-// @ts-ignore
 import { {{classname}}, ModelFields{{classname}}, modelFields{{classname}} } from '{{filename}}';
 {{/tsImports}}
-// prettier-ignore
-// @ts-ignore
 import { ModelFieldArray, ModelFieldboolean, ModelFieldnumber, ModelFieldObject, ModelFields, ModelFieldstring, removeAdditionalProperties } from '../../model-field';
 
 export interface {{classname}}{{#allParents}}{{#-first}} extends {{/-first}}{{{.}}}{{^-last}}, {{/-last}}{{/allParents}} { {{>modelGenericAdditionalProperties}}


### PR DESCRIPTION
Since we use prettier-plugin-organize-imports in moneymeets-app, unused imports are removed automatically.

Thus, we don't need the comments for @ts-ignore and prettier-ignore comments any longer.